### PR TITLE
optimize center cursor logic

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -229,6 +229,15 @@ if [ "$OBSERVE_STATE" = "true" ]; then
   )
 fi
 
+hyprctl monitors -j |
+jq -r '
+  .[] |
+  "\(.id) \(.x + (.width/.scale/2)) \(.y + (.height/.scale/2))"
+' | while read id cx cy; do
+  echo "$cx $cy" > "$STATE_DIR/monitor_center_$id"
+done
+
+
 # Sudo handling depending on requireSudo
 # (leave only the refresh/trap logic here)
 auto_destroy=$(jq -r '.autoDestroyOnExit // true' "$PROFILE_CONFIG_FILE")

--- a/scripts/toggle_mode.sh
+++ b/scripts/toggle_mode.sh
@@ -68,6 +68,13 @@ hyprctl --batch "
   keyword input:sensitivity $TARGET_SENSITIVITY;
   dispatch focuswindow address:$WINDOW_ADDRESS
 "
+LAST_MONITOR_FILE="$STATE_DIR/last_monitor"
+
+if [ -n "$MONITOR_ID" ]; then
+  read -r LAST_MONITOR 2>/dev/null < "$LAST_MONITOR_FILE" || LAST_MONITOR=""
+  [ "$LAST_MONITOR" != "$MONITOR_ID" ] && echo "$MONITOR_ID" > "$LAST_MONITOR_FILE"
+fi
+
 
 # Run onEnter: run all commands in array
 export WINDOW_ADDRESS HYPRMCSR_PROFILE PRISM_INSTANCE_ID MINECRAFT_ROOT PREVIOUS_MODE NEXT_MODE

--- a/scripts/toggle_mode.sh
+++ b/scripts/toggle_mode.sh
@@ -49,9 +49,9 @@ fi
 # Update state
 echo "$NEXT_MODE" > "$STATE_FILE"
 
+MONITOR_ID=$(hyprctl clients -j | jq -r ".[] | select(.address==\"$WINDOW_ADDRESS\") | .monitor")
 # Handle fullscreen size
 if [ "$TARGET_SIZE" = "fullscreen" ]; then
-  MONITOR_ID=$(hyprctl clients -j | jq -r ".[] | select(.address==\"$WINDOW_ADDRESS\") | .monitor")
   read WIDTH HEIGHT SCALE <<<$(hyprctl monitors -j | jq -r ".[] | select(.id==$MONITOR_ID) | \"\(.width) \(.height) \(.scale)\"")
   TARGET_WIDTH=$(awk "BEGIN {printf \"%.0f\", $WIDTH / $SCALE}")
   TARGET_HEIGHT=$(awk "BEGIN {printf \"%.0f\", $HEIGHT / $SCALE}")

--- a/util/center_cursor.sh
+++ b/util/center_cursor.sh
@@ -15,7 +15,22 @@ else
 fi
 
 CACHE="$STATE_DIR/monitor_center_$MONITOR_ID"
-[ ! -f "$CACHE" ] && exit 0
+if [ ! -s "$CACHE" ]; then
+  read CENTER_X CENTER_Y <<<"$(
+  hyprctl monitors -j |
+  jq -r --argjson mid "$MONITOR_ID" '
+      .[] |
+      select(.id == $mid) |
+      [
+        (.x + (.width / .scale / 2)),
+        (.y + (.height / .scale / 2))
+      ] |
+      @sh
+    '
+  )"
+  echo "$CENTER_X $CENTER_Y" > "$STATE_DIR/monitor_center_$MONITOR_ID"
+else
+  read CENTER_X CENTER_Y < "$CACHE"
+fi
 
-read CENTER_X CENTER_Y < "$CACHE"
 hyprctl -q dispatch movecursor "$CENTER_X" "$CENTER_Y"

--- a/util/center_cursor.sh
+++ b/util/center_cursor.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
-# Centers the cursor on the monitor where the Minecraft window is located
+# Cursor centering for Minecraft window
+
 export SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 source "$SCRIPT_DIR/../util/env_runtime.sh"
 
-# Get the monitor ID (numeric) of the window
-MONITOR_ID=$(hyprctl clients -j | jq -r ".[] | select(.address==\"$WINDOW_ADDRESS\") | .monitor")
+LAST_MONITOR_FILE="$STATE_DIR/last_monitor"
 
-# Get the geometry and scale of the monitor based on the ID
-read X Y WIDTH HEIGHT SCALE <<<$(hyprctl monitors -j | jq -r ".[] | select(.id==$MONITOR_ID) | \"\(.x) \(.y) \(.width) \(.height) \(.scale)\"")
+# Try cached monitor first
+if [ -f "$LAST_MONITOR_FILE" ]; then
+  MONITOR_ID=$(cat "$LAST_MONITOR_FILE")
+else
+  MONITOR_ID=$(hyprctl clients -j | jq -r ".[] | select(.address==\"$WINDOW_ADDRESS\") | .monitor")
+  [ -n "$MONITOR_ID" ] && echo "$MONITOR_ID" > "$LAST_MONITOR_FILE"
+fi
 
-# Calculate effective dimensions (divided by scale)
-# Use awk for float division
-EFFECTIVE_WIDTH=$(awk "BEGIN {printf \"%.0f\", $WIDTH / $SCALE}")
-EFFECTIVE_HEIGHT=$(awk "BEGIN {printf \"%.0f\", $HEIGHT / $SCALE}")
+CACHE="$STATE_DIR/monitor_center_$MONITOR_ID"
+[ ! -f "$CACHE" ] && exit 0
 
-CENTER_X=$((X + EFFECTIVE_WIDTH / 2))
-CENTER_Y=$((Y + EFFECTIVE_HEIGHT / 2))
-
+read CENTER_X CENTER_Y < "$CACHE"
 hyprctl -q dispatch movecursor "$CENTER_X" "$CENTER_Y"


### PR DESCRIPTION
Cache the last active monitor ID and precomputed monitor center coordinates in $STATE_DIR. The monitor ID is updated only on change, and per-monitor center positions are stored for fast cursor centering without recalculating geometry each time, reducing overhead in performance-critical paths.